### PR TITLE
.NET Core 2.2 as default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-dotnet_package: "dotnet-sdk-2.1.105"
+dotnet_package: "dotnet-sdk-2.2"
 dotnet_debian_repo_gpg_key_url: "https://packages.microsoft.com/keys/microsoft.asc"


### PR DESCRIPTION
Can we have `dotnet-sdk-2.2` as default? I've been using it in a `host_vars` but I think most people would like it as default.